### PR TITLE
VIM-2314: Upload Quota Exceptions

### DIFF
--- a/VIMNetworking/Networking/Upload/UploadTaskQueue/VIMUploadSessionManager.m
+++ b/VIMNetworking/Networking/Upload/UploadTaskQueue/VIMUploadSessionManager.m
@@ -76,7 +76,7 @@
         self.requestSerializer = [VIMRequestSerializer serializerWithSession:[VIMSession sharedSession]];
         self.responseSerializer = [VIMResponseSerializer serializerWithReadingOptions:NSJSONReadingAllowFragments];
 
-#ifndef DEBUG
+#ifdef RELEASE
         self.securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
         self.securityPolicy.allowInvalidCertificates = NO;
         self.securityPolicy.validatesCertificateChain = NO;

--- a/VIMNetworking/Networking/Upload/UploadTaskQueue/VIMUploadTask.m
+++ b/VIMNetworking/Networking/Upload/UploadTaskQueue/VIMUploadTask.m
@@ -273,14 +273,14 @@ static void *UploadProgressContext = &UploadProgressContext;
     {
         self.error = task.error;
 
+        [self progress:task];
+        
+        [self taskDidComplete];
+
         if (task.error.code != NSURLErrorCancelled)
         {
             self.uploadState = VIMUploadState_Failed;
         }
-
-        [self progress:task];
-
-        [self taskDidComplete];
     }
 }
 
@@ -305,14 +305,14 @@ static void *UploadProgressContext = &UploadProgressContext;
     {
         self.error = task.error;
         
+        [self progress:task];
+        
+        [self taskDidComplete];
+
         if (task.error.code != NSURLErrorCancelled)
         {
             self.uploadState = VIMUploadState_Failed;
         }
-   
-        [self progress:task];
-
-        [self taskDidComplete];
     }
 }
 
@@ -337,25 +337,25 @@ static void *UploadProgressContext = &UploadProgressContext;
         }
         else
         {
-            self.uploadState = VIMUploadState_Succeeded;
-
             [self progress:task];
-
+            
             [self taskDidComplete];
+
+            self.uploadState = VIMUploadState_Succeeded;
         }
     }
     else
     {
         self.error = task.error;
 
+        [self progress:task];
+        
+        [self taskDidComplete];
+
         if (task.error.code != NSURLErrorCancelled)
         {
             self.uploadState = VIMUploadState_Failed;
         }
-
-        [self progress:task];
-        
-        [self taskDidComplete];
     }
 }
 
@@ -363,21 +363,25 @@ static void *UploadProgressContext = &UploadProgressContext;
 {
     if ([task didSucceed])
     {
+        [self progress:task];
+        
+        [self taskDidComplete];
+
         self.uploadState = VIMUploadState_Succeeded;
     }
     else
     {
         self.error = task.error;
 
+        [self progress:task];
+        
+        [self taskDidComplete];
+
         if (task.error.code != NSURLErrorCancelled)
         {
             self.uploadState = VIMUploadState_Failed;
         }
-    }
-    
-    [self progress:task];
-    
-    [self taskDidComplete];
+    }    
 }
 
 - (void)progress:(VIMTask *)subtask

--- a/VIMNetworking/Networking/Upload/UploadTaskQueue/VIMUploadTaskQueueTracker.m
+++ b/VIMNetworking/Networking/Upload/UploadTaskQueue/VIMUploadTaskQueueTracker.m
@@ -112,10 +112,14 @@ static void *UploadStateContext = &UploadStateContext;
     
     [self.failedAssets removeObjectAtIndex:index];
     
-    NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_AssetIndicesKey : @[@(index)]};
-    [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRemoveFailedAssetsNotification
-                                                        object:self.failedAssets
-                                                      userInfo:userInfo];
+    dispatch_async(dispatch_get_main_queue(), ^{
+
+        NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_AssetIndicesKey : @[@(index)]};
+        [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRemoveFailedAssetsNotification
+                                                            object:self.failedAssets
+                                                          userInfo:userInfo];
+
+    });
 }
 
 - (VIMVideoAsset *)assetForIdentifier:(NSString *)identifier
@@ -175,8 +179,12 @@ static void *UploadStateContext = &UploadStateContext;
 
         _currentVideoAsset = currentVideoAsset;
         
-        [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_CurrentVideoAssetDidChangeNotification
-                                                            object:currentVideoAsset];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            
+            [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_CurrentVideoAssetDidChangeNotification
+                                                                object:currentVideoAsset];
+        
+        });
     }
 }
 
@@ -243,8 +251,12 @@ static void *UploadStateContext = &UploadStateContext;
             [self uploadState:videoAsset.uploadState didChangeForVideoAsset:videoAsset];
         }
     
-        [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRefreshQueuedAssetsNotification
-                                                            object:nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRefreshQueuedAssetsNotification
+                                                                object:nil];
+        
+        });
         
         [self save];
     }
@@ -292,27 +304,35 @@ static void *UploadStateContext = &UploadStateContext;
         {
             if (failedIndex != NSNotFound)
             {
-                NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_OriginalIndexKey : @(failedIndex),
-                                           VIMUploadTaskQueueTracker_NewIndexKey : @([self.videoAssets count] - 1),
-                                           VIMUploadTaskQueueTracker_QueuedAssetsKey : self.videoAssets,
-                                           VIMUploadTaskQueueTracker_FailedAssetsKey : self.failedAssets,
-                                           VIMUploadTaskQueueTracker_AssetsKey : object,
-                                           VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
-                [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_FailedAssetDidRetryNotification
-                                                                    object:nil
-                                                                  userInfo:userInfo];
-            
+                dispatch_async(dispatch_get_main_queue(), ^{
+
+                    NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_OriginalIndexKey : @(failedIndex),
+                                               VIMUploadTaskQueueTracker_NewIndexKey : @([self.videoAssets count] - 1),
+                                               VIMUploadTaskQueueTracker_QueuedAssetsKey : self.videoAssets,
+                                               VIMUploadTaskQueueTracker_FailedAssetsKey : self.failedAssets,
+                                               VIMUploadTaskQueueTracker_AssetsKey : object,
+                                               VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
+                    [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_FailedAssetDidRetryNotification
+                                                                        object:nil
+                                                                      userInfo:userInfo];
+
+                });
+                
                 return;
             }
         }
 
-        NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_AssetIndicesKey : indices,
-                                   VIMUploadTaskQueueTracker_AssetsKey : object,
-                                   VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
-        [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidAddQueuedAssetsNotification
-                                                            object:self.videoAssets
-                                                          userInfo:userInfo];        
+        dispatch_async(dispatch_get_main_queue(), ^{
 
+            NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_AssetIndicesKey : indices,
+                                       VIMUploadTaskQueueTracker_AssetsKey : object,
+                                       VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
+            [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidAddQueuedAssetsNotification
+                                                                object:self.videoAssets
+                                                              userInfo:userInfo];        
+
+        });
+        
         [self save];
     }
 }
@@ -348,12 +368,16 @@ static void *UploadStateContext = &UploadStateContext;
 
         [self.videoAssets removeObjectAtIndex:index];
         
-        NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_AssetIndicesKey : @[@(index)],
-                                   VIMUploadTaskQueueTracker_AssetsKey : @[object],
-                                   VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
-        [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRemoveQueuedAssetsNotification
-                                                            object:self.videoAssets
-                                                          userInfo:userInfo];
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_AssetIndicesKey : @[@(index)],
+                                       VIMUploadTaskQueueTracker_AssetsKey : @[object],
+                                       VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
+            [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRemoveQueuedAssetsNotification
+                                                                object:self.videoAssets
+                                                              userInfo:userInfo];
+
+        });
         
         [self save];
     }
@@ -376,8 +400,12 @@ static void *UploadStateContext = &UploadStateContext;
     [self.videoAssets removeAllObjects];
     self.currentVideoAsset = nil;
     
-    [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRefreshQueuedAssetsNotification
-                                                        object:self.videoAssets];
+    dispatch_async(dispatch_get_main_queue(), ^{
+
+        [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRefreshQueuedAssetsNotification
+                                                            object:self.videoAssets];
+
+    });
     
     [self save];
 }
@@ -397,9 +425,13 @@ static void *UploadStateContext = &UploadStateContext;
         [self.successfulAssetIdentifiers removeAllObjects];
         [self.failedAssets removeAllObjects];
         
-        [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRefreshQueuedAssetsNotification
-                                                            object:self.videoAssets];
+        dispatch_async(dispatch_get_main_queue(), ^{
 
+            [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRefreshQueuedAssetsNotification
+                                                                object:self.videoAssets];
+
+        });
+        
         [self save];
     }
 }
@@ -483,13 +515,17 @@ static void *UploadStateContext = &UploadStateContext;
 
             [self.videoAssets removeObjectAtIndex:index];
             
-            NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_AssetIndicesKey : @[@(index)],
-                                       VIMUploadTaskQueueTracker_AssetsKey : @[videoAsset],
-                                       VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
-            [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRemoveQueuedAssetsNotification
-                                                                object:self.videoAssets
-                                                              userInfo:userInfo];
+            dispatch_async(dispatch_get_main_queue(), ^{
 
+                NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_AssetIndicesKey : @[@(index)],
+                                           VIMUploadTaskQueueTracker_AssetsKey : @[videoAsset],
+                                           VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
+                [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_DidRemoveQueuedAssetsNotification
+                                                                    object:self.videoAssets
+                                                                  userInfo:userInfo];
+
+            });
+            
             break;
         }
         case VIMUploadState_Failed:
@@ -509,15 +545,19 @@ static void *UploadStateContext = &UploadStateContext;
 
                 [self.videoAssets removeObjectAtIndex:index];
 
-                NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_OriginalIndexKey : @(index),
-                                           VIMUploadTaskQueueTracker_NewIndexKey : @([self.failedAssets count] - 1),
-                                           VIMUploadTaskQueueTracker_QueuedAssetsKey : self.videoAssets,
-                                           VIMUploadTaskQueueTracker_FailedAssetsKey : self.failedAssets,
-                                           VIMUploadTaskQueueTracker_AssetsKey : @[videoAsset],
-                                           VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
-                [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_QueuedAssetDidFailNotification
-                                                                    object:nil
-                                                                  userInfo:userInfo];
+                dispatch_async(dispatch_get_main_queue(), ^{
+
+                    NSDictionary *userInfo = @{VIMUploadTaskQueueTracker_OriginalIndexKey : @(index),
+                                               VIMUploadTaskQueueTracker_NewIndexKey : @([self.failedAssets count] - 1),
+                                               VIMUploadTaskQueueTracker_QueuedAssetsKey : self.videoAssets,
+                                               VIMUploadTaskQueueTracker_FailedAssetsKey : self.failedAssets,
+                                               VIMUploadTaskQueueTracker_AssetsKey : @[videoAsset],
+                                               VIMUploadTaskQueueTracker_SessionIdentifierKey : self.sessionIdentifier};
+                    [[NSNotificationCenter defaultCenter] postNotificationName:VIMUploadTaskQueueTracker_QueuedAssetDidFailNotification
+                                                                        object:nil
+                                                                      userInfo:userInfo];
+                    
+                });
             }
             break;
         }

--- a/VIMNetworking/Networking/VimeoClient/VIMRequestOperationManager.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMRequestOperationManager.m
@@ -80,7 +80,7 @@ NSString * const kVimeoClientErrorDomain = @"VimeoClientErrorDomain";
         self.requestSerializer = [VIMRequestSerializer serializerWithSession:[VIMSession sharedSession]];
         self.responseSerializer = [VIMResponseSerializer serializer];        
     
-#ifndef DEBUG
+#ifdef RELEASE
         self.securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
         self.securityPolicy.allowInvalidCertificates = NO;
         self.securityPolicy.validatesCertificateChain = NO;


### PR DESCRIPTION
Modified task completion logic so that task.error is set before task.state, specifically so that error can be read during KVO on failure_state.

https://vimean.atlassian.net/browse/VIM-2314