### PR TITLE
Rough edges

### DIFF
--- a/VIMNetworking/Networking/VimeoClient/VIMSession.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSession.m
@@ -104,6 +104,11 @@ static VIMSession *_sharedSession;
         [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
     });
 
+    if (self.currentUserRefreshRequest)
+    {
+        return;
+    }
+    
     __weak typeof(self) weakSelf = self;
     self.currentUserRefreshRequest = [self refreshAuthenticatedUserWithCompletionBlock:^(NSError *error) {
         


### PR DESCRIPTION
This branch cleans up a few rough edges around the recent accounts work. 

- Users who log in to previous app version, upgrade to new version, and logout. They lack a cached client credentials account. This fully logs them out and fetches new cc account. 

- A few other things... :)