### PR TITLE
Task Queue Thread Safety 

### DIFF
--- a/VIMNetworking/Networking/Upload/TaskQueue/VIMTaskQueue.m
+++ b/VIMNetworking/Networking/Upload/TaskQueue/VIMTaskQueue.m
@@ -332,7 +332,7 @@ static void *TaskQueueSpecific = "TaskQueueSpecific";
     
     if (self.currentTask)
     {
-        archiveDictionary[CurrentTaskKey] = self.currentTask;
+        archiveDictionary[CurrentTaskKey] = [self.currentTask copy];
     }
     
     NSLog(@"SAVING: %@", dictionary);

--- a/VIMNetworking/Networking/Upload/TaskQueue/VIMTaskQueue.m
+++ b/VIMNetworking/Networking/Upload/TaskQueue/VIMTaskQueue.m
@@ -197,9 +197,9 @@ static void *TaskQueueSpecific = "TaskQueueSpecific";
 
     self.suspended = NO;
     
-    [self save];
-
     dispatch_async(_tasksQueue, ^{
+
+        [self save];
 
         [self restart];
     

--- a/VIMNetworking/Networking/Upload/TaskQueue/VIMTaskQueue.m
+++ b/VIMNetworking/Networking/Upload/TaskQueue/VIMTaskQueue.m
@@ -176,12 +176,16 @@ static void *TaskQueueSpecific = "TaskQueueSpecific";
     
     self.suspended = YES;
     
-    if (self.currentTask)
-    {
-        [self.currentTask suspend];
-    }
-    
-    [self save];
+    dispatch_async(_tasksQueue, ^{
+
+        if (self.currentTask)
+        {
+            [self.currentTask suspend];
+        }
+        
+        [self save];
+        
+    });
 }
 
 - (void)resume
@@ -209,15 +213,34 @@ static void *TaskQueueSpecific = "TaskQueueSpecific";
         return nil;
     }
     
-    if ([self.currentTask.identifier isEqualToString:identifier])
+    __block VIMTask *task = nil;
+
+    if (dispatch_get_specific(TaskQueueSpecific))
     {
-        return self.currentTask;
+        task = [self _taskForIdentifier:identifier];
+    }
+    else
+    {
+        dispatch_sync(_tasksQueue, ^{ // TODO: Is this a problem when [self.tasks count] is large? [AH]
+
+            task = [self _taskForIdentifier:identifier];
+            
+        });
     }
     
-    __block VIMTask *task = nil;
-    
-    dispatch_sync(_tasksQueue, ^{ // TODO: Is this a problem when [self.tasks count] is large? [AH]
+    return task;
+}
 
+- (VIMTask *)_taskForIdentifier:(NSString *)identifier
+{
+    VIMTask *task = nil;
+    
+    if ([self.currentTask.identifier isEqualToString:identifier])
+    {
+        task = self.currentTask;
+    }
+    else
+    {
         for (VIMTask *currentTask in self.tasks)
         {
             if ([currentTask.identifier isEqualToString:identifier])
@@ -225,15 +248,14 @@ static void *TaskQueueSpecific = "TaskQueueSpecific";
                 task = currentTask;
             }
         }
-
-    });
+    }
     
     return task;
 }
 
 - (void)prepareTask:(VIMTask *)task
 {
-    // Optional subclass override 
+    // Optional subclass override
 }
 
 - (NSUserDefaults *)taskQueueDefaults


### PR DESCRIPTION
Comments from marc:

Alfie,

was helping today Mark Essel with refactoring this code, and notice the following:

 we can discuss but I think these safety are needed I feel. Look at <<<<< inserted this
maybe resume case is debatable because it is paused anyway...

- (void)suspend
{
    if (self.isSuspended)
    {
        return;
    }
    
    self.suspended = YES;
    

dispatch_async(_tasksQueue, ^{ <<<<<< inserted this:

             if (self.currentTask)
           {
              [self.currentTask suspend];
          }
    
         [self save];
 }
}

- (void)resume
{
    if (!self.isSuspended)
    {
        return;
    }

    self.suspended = NO;

    dispatch_async(_tasksQueue, ^{ <<<<<< inserted this:

              [self save];

           dispatch_async(_tasksQueue, ^{

                 [self restart];
    
           });
   }
}

- (VIMTask *)taskForIdentifier:(NSString *)identifier
{
    if (!identifier)
    {
        return nil;
    }
    
<<<<<< should line below not be part of
dispatch_sync(_tasksQueue, also should it not also use the WWDC 2015 technique? I think you mentioned that during our meeting.


    if ([self.currentTask.identifier isEqualToString:identifier])
    {
        return self.currentTask;
    }
    
    __block VIMTask *task = nil;
    
    dispatch_sync(_tasksQueue, ^{ // TODO: Is this a problem when [self.tasks count] is large? [AH]

        for (VIMTask *currentTask in self.tasks)
        {
            if ([currentTask.identifier isEqualToString:identifier])
            {
                task = currentTask;
            }
        }

    });
    
    return task;
}
