### PR TITLE
some fixes to VIMClient regarding initialization and base URL swapping

### DIFF
--- a/VIMNetworking/Networking/VimeoClient/VIMClient.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMClient.m
@@ -41,9 +41,9 @@ static NSString *const ModelKeyPathData = @"data";
 
 @implementation VIMClient
 
-- (instancetype)init
+- (instancetype)initWithBaseURL:(NSURL *)url
 {
-    self = [super init];
+    self = [super initWithBaseURL:url];
     if (self)
     {
         _retryManager = [[VIMRequestRetryManager alloc] initWithName:@"VIMClientRetryManager" operationManager:self];

--- a/VIMNetworking/Networking/VimeoClient/VIMSession.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSession.m
@@ -420,7 +420,7 @@ static VIMSession *_sharedSession;
 {
     NSParameterAssert(baseURLString);
     
-    if (baseURLString == nil)
+    if (baseURLString == nil || [self.configuration.baseURLString isEqualToString:baseURLString])
     {
         return NO;
     }


### PR DESCRIPTION
@alfiehanssen This branch fixes two issues I came across with the new VIMClient structure when I was fixing a bug where deeplinks would not launch properly.

1.  in VIMSession's -buildClient, initWithBaseURL is used to create VIMClient, meaning that -init was never actually used on that class, and VIMRetryManager was always null.  I modified the VIMClient initializer to correctly override the superclass initializer.
2.  When the base URL changed method of VIMSession is called (every time /configs loads, at minimum), VIMClient was always recreated anew regardless of whether it was necessary or not.  This caused issues with requests that were already in progress because the weakSelf of VIMClient in those completion blocks became nil, so naturally any further action requested therein was silently ignored.  For now, I've added a check to stop any unnecessary swapping of VIMClient.  If swapping the base URL somehow becomes necessary as a normal course of launch, we'll probably need to deal more deeply with this issue.