### PR TITLE
Convenience Initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,27 @@ With `VIMNetworking` configured and authenticated, you’re ready to start makin
 
 ```
 
+You can also make requests using an existing token by implementing the authorizationHeaderValue: method of VIMRequestOperationManagerDelegate.
+
+```Objective-C
+
+self.client = [[VIMClient alloc] initWithDefaultBaseURL];
+self.client.delegate = self;
+[self.client requestURI:@"/videos/77091919" completionBlock:^(VIMServerResponse *response, NSError *error)
+{
+    id JSONObject = response.result;
+    NSLog(@"JSONObject: %@", JSONObject);
+}];
+
+# pragma mark - VIMRequestOperationManagerDelegate
+
+- (NSString *)authorizationHeaderValue:(nonnull VIMRequestOperationManager *)operationManager
+{
+    return [NSString stringWithFormat:@"Bearer <TOKEN>"];
+}
+
+```
+
 ### Model Object Request
 
 ```Objective-C

--- a/VIMNetworking/Networking/VimeoClient/VIMClient.h
+++ b/VIMNetworking/Networking/VimeoClient/VIMClient.h
@@ -31,6 +31,8 @@
 
 @interface VIMClient : VIMRequestOperationManager
 
+- (nullable instancetype)initWithDefaultBaseURL;
+
 #pragma mark - Utilities
 
 - (nullable id<VIMRequestToken>)resetPasswordWithEmail:(nonnull NSString *)email completionBlock:(nonnull VIMRequestCompletionBlock)completionBlock;

--- a/VIMNetworking/Networking/VimeoClient/VIMClient.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMClient.m
@@ -30,6 +30,7 @@
 #import "VIMComment.h"
 #import "VIMTrigger.h"
 #import "VIMRequestRetryManager.h"
+#import "VIMSessionConfiguration.h"
 
 static NSString *const ModelKeyPathData = @"data";
 
@@ -40,6 +41,11 @@ static NSString *const ModelKeyPathData = @"data";
 @end
 
 @implementation VIMClient
+
+- (instancetype)initWithDefaultBaseURL
+{
+    return [self initWithBaseURL:[NSURL URLWithString:DefaultBaseURL]];
+}
 
 - (instancetype)initWithBaseURL:(NSURL *)url
 {

--- a/VIMNetworking/Networking/VimeoClient/VIMSessionConfiguration.h
+++ b/VIMNetworking/Networking/VimeoClient/VIMSessionConfiguration.h
@@ -26,6 +26,8 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSString * const __nullable DefaultBaseURL;
+
 @interface VIMSessionConfiguration : NSObject
 
 @property (nonatomic, copy, nullable) NSString *clientKey;

--- a/VIMNetworking/Networking/VimeoClient/VIMSessionConfiguration.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSessionConfiguration.m
@@ -27,6 +27,8 @@
 #import "VIMSessionConfiguration.h"
 #import <Foundation/Foundation.h>
 
+NSString * const DefaultBaseURL = @"https://api.vimeo.com/";
+
 @implementation VIMSessionConfiguration
 
 - (instancetype)init
@@ -35,7 +37,7 @@
     if (self)
     {
         _APIVersionString = @"3.2";
-        _baseURLString = @"https://api.vimeo.com/";
+        _baseURLString = DefaultBaseURL;
     }
     
     return self;


### PR DESCRIPTION
We can now more easily make simple requests with an existing token without using local sessions.

```objective-c
self.client = [[VIMClient alloc] initWithDefaultBaseURL];
self.client.delegate = self;
[self.client requestURI:@"/videos/77091919" completionBlock:^(VIMServerResponse *response, NSError *error)
{
    id JSONObject = response.result;
    NSLog(@"JSONObject: %@", JSONObject);
}];

# pragma mark - VIMRequestOperationManagerDelegate

- (NSString *)authorizationHeaderValue:(nonnull VIMRequestOperationManager *)operationManager
{
    return [NSString stringWithFormat:@"Bearer <TOKEN>"];
}
```