### PR TITLE
Additional Error Check in Upload CREATE Task

### DIFF
--- a/VIMNetworking/Networking/Upload/UploadTaskQueue/Subtasks/VIMCreateTicketTask.m
+++ b/VIMNetworking/Networking/Upload/UploadTaskQueue/Subtasks/VIMCreateTicketTask.m
@@ -261,7 +261,14 @@ static const NSString *VIMCreateRecordTaskName = @"CREATE";
 
         return;
     }
-    
+
+    if (self.error)
+    {
+        [self taskDidComplete];
+        
+        return;
+    }
+
     if (task.error)
     {
         self.error = [NSError errorWithError:task.error domain:VIMCreateRecordTaskErrorDomain URLResponse:task.response];


### PR DESCRIPTION
We may have not been checking for certain upfront create errors, in which case they would be reported as upload_link_secure missing errors.

https://vimean.atlassian.net/browse/VIM-2724