### PR TITLE
VIMVideoAsset KVO Crash Fix

### DIFF
--- a/VIMNetworking/Networking/Upload/UploadTaskQueue/VIMUploadTaskQueueTracker.m
+++ b/VIMNetworking/Networking/Upload/UploadTaskQueue/VIMUploadTaskQueueTracker.m
@@ -160,7 +160,7 @@ static void *UploadStateContext = &UploadStateContext;
 
 #pragma mark - Private API
 
-- (NSInteger)indexOfFailedAsset:(VIMVideoAsset *)videoAsset completion:(void (^)(NSInteger index, VIMVideoAsset *asset))completion
+- (void)indexOfFailedAsset:(VIMVideoAsset *)videoAsset completion:(void (^)(NSInteger index, VIMVideoAsset *asset))completion
 {
     NSInteger index = NSNotFound;
     VIMVideoAsset *asset = nil;
@@ -181,8 +181,6 @@ static void *UploadStateContext = &UploadStateContext;
     {
         completion(index, asset);
     }
-    
-    return NSNotFound;
 }
 
 #pragma mark - Accessors


### PR DESCRIPTION
Crash fix for observers not being removed before videoAsset is deallocated.

https://vimean.atlassian.net/browse/VIM-2749

https://rink.hockeyapp.net/manage/apps/106799/app_versions/18/crash_reasons/42764703