### PR TITLE
Potential fix for issue where expires check always fails

### DIFF
--- a/VIMNetworking/Model/VIMVideoFile.m
+++ b/VIMNetworking/Model/VIMVideoFile.m
@@ -110,9 +110,14 @@ NSString *const VIMVideoFileQualityMobile = @"mobile";
 
 - (BOOL)isExpired
 {
+    if (!self.expirationDate) // This will yield NSOrderedSame (weird), so adding an explicit check here [AH] 9/14/2015
+    {
+        return NO;
+    }
+    
     NSComparisonResult result = [[NSDate date] compare:self.expirationDate];
     
-    return (result == NSOrderedDescending || result == NSOrderedSame);
+    return (result == NSOrderedDescending);
 }
 
 @end


### PR DESCRIPTION
A nil expiration date evaluates to NSOrderedSame (seems counterintuitive to me), removing NSOrderedSame from the check. 

https://vimean.atlassian.net/browse/VIM-2845