### PR TITLE
VIM-2845: Fix timezone format issue

### DIFF
--- a/VIMNetworking/Model/VIMVideo.m
+++ b/VIMNetworking/Model/VIMVideo.m
@@ -78,13 +78,6 @@ NSString *VIMContentRating_Safe = @"safe";
     return [self.interactions objectForKey:name];
 }
 
-- (NSDateFormatter *)dateFormatter
-{
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-	[dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZ"];
-    return dateFormatter;
-}
-
 #pragma mark - VIMMappable
 
 - (NSDictionary *)getObjectMapping


### PR DESCRIPTION
https://vimean.atlassian.net/browse/VIM-2845

This specifies locale whenever we're creating a date formatter. 