### PR TITLE
Keychain Access Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ On app launch, configure `VIMSession` with your client key, secret, and scope st
 
 ```
 
+Note that you must specify a value for `keychainService` and can optionally provide a value for `keychainAccessGroup`. The role of the latter value is detailed [here](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html) in the section on Keychain Access Groups.
+
 ## Authentication 
 
 All calls to the Vimeo API must be [authenticated](https://developer.vimeo.com/api/authentication). This means that before making requests to the API you must authenticate and obtain an access token. Two authentication methods are provided: 

--- a/VIMNetworking/Networking/VimeoClient/VIMSessionConfiguration.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSessionConfiguration.m
@@ -53,10 +53,9 @@ NSString *const DefaultAPIVersionString = @"3.2";
     NSParameterAssert(self.scope);
     NSParameterAssert(self.baseURLString);
     NSParameterAssert(self.APIVersionString);
-    NSParameterAssert(self.keychainAccessGroup);
     NSParameterAssert(self.keychainService);
     
-    return self.clientKey && self.clientSecret && self.scope && self.baseURLString && self.APIVersionString && self.keychainAccessGroup && self.keychainService;
+    return self.clientKey && self.clientSecret && self.scope && self.baseURLString && self.APIVersionString && self.keychainService;
 }
 
 @end


### PR DESCRIPTION
Keychain access group is optional but the session configuration `isValid` method was treating it as if it was non optional. Fixes issue #138.