### PR TITLE
VIM-2934: Only posting accountDidChange notification when the account actually changed!

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ On app launch, configure `VIMSession` with your client key, secret, and scope st
 
 ```
 
+Note that you must specify a value for `keychainService` and can optionally provide a value for `keychainAccessGroup`. The role of the latter value is detailed [here](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html) in the section on Keychain Access Groups.
+
 ## Authentication 
 
 All calls to the Vimeo API must be [authenticated](https://developer.vimeo.com/api/authentication). This means that before making requests to the API you must authenticate and obtain an access token. Two authentication methods are provided: 

--- a/VIMNetworking.podspec
+++ b/VIMNetworking.podspec
@@ -1,14 +1,13 @@
 Pod::Spec.new do |s|
 
   s.name         = "VIMNetworking"
-  s.version      = "5.6.1.12"
+  s.version      = "5.6.1.13"
   s.summary      = "The Vimeo iOS SDK"
   s.description  = <<-DESC
                    VIMNetworking is an Objective-C library that enables interaction with the Vimeo API. It handles authentication, request submission and cancellation, and video upload. Advanced features include caching and powerful model object parsing.
                    DESC
 
   s.homepage     = "https://github.com/vimeo/VIMNetworking"
-  s.license      = "MIT"
   s.license      = { :type => "MIT", :file => "LICENSE.md" }
 
   s.authors            = { "Alfie Hanssen" => "alfiehanssen@gmail.com",

--- a/VIMNetworking/Networking/VimeoClient/VIMSession.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSession.m
@@ -103,13 +103,18 @@ static VIMSession *_sharedSession;
 
 - (void)applicationDidEnterForeground:(NSNotification *)notification
 {
+    VIMAccountNew *originalAccount = self.account;
+    
     self.account = [self loadAccountIfPossible]; // Reload account in the event that an auth event occurred in the an app extension
     self.client.cache = [self buildCache];
 
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
-    });
-
+    if (![originalAccount.accessToken isEqualToString:self.account.accessToken])
+    {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
+        });
+    }
+    
     if (self.currentUserRefreshRequest)
     {
         return;
@@ -270,12 +275,16 @@ static VIMSession *_sharedSession;
         NSLog(@"Unable to save account for key: %@", key);
     }
 
+    VIMAccountNew *originalAccount = self.account;
     self.account = account;
     self.client.cache = [self buildCache];
     
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
-    });
+    if (![originalAccount.accessToken isEqualToString:self.account.accessToken])
+    {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
+        });
+    }
     
     if (completionBlock)
     {
@@ -386,6 +395,7 @@ static VIMSession *_sharedSession;
         NSLog(@"Unable to delete account for key: %@", UserAccountKey);
     }
     
+    VIMAccountNew *originalAccount = self.account;
     self.account = account;
     
     [self.client.cache removeAllObjects];
@@ -401,9 +411,12 @@ static VIMSession *_sharedSession;
         return nil;
     }
     
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
-    });
+    if (![originalAccount.accessToken isEqualToString:self.account.accessToken])
+    {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
+        });
+    }
 
     return logoutRequest;
 }
@@ -435,12 +448,16 @@ static VIMSession *_sharedSession;
         NSLog(@"Unable to save account");
     }
     
+    VIMAccountNew *originalAccount = self.account;
     self.account = account;
     self.client.cache = [self buildCache];
     
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
-    });
+    if (![originalAccount.accessToken isEqualToString:self.account.accessToken])
+    {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
+        });
+    }
     
     return YES;
 }

--- a/VIMNetworking/Networking/VimeoClient/VIMSessionConfiguration.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSessionConfiguration.m
@@ -53,10 +53,9 @@ NSString *const DefaultAPIVersionString = @"3.2";
     NSParameterAssert(self.scope);
     NSParameterAssert(self.baseURLString);
     NSParameterAssert(self.APIVersionString);
-    NSParameterAssert(self.keychainAccessGroup);
     NSParameterAssert(self.keychainService);
     
-    return self.clientKey && self.clientSecret && self.scope && self.baseURLString && self.APIVersionString && self.keychainAccessGroup && self.keychainService;
+    return self.clientKey && self.clientSecret && self.scope && self.baseURLString && self.APIVersionString && self.keychainService;
 }
 
 @end


### PR DESCRIPTION
This notification was being posted even if the "new" account was the same as the "old" account. Now it's only being posted if the accounts' auth tokens differ.

https://vimean.atlassian.net/browse/VIM-2934
