### PR TITLE
VIM-3308: Remove unused download-specific methods

### DIFF
--- a/VIMNetworking/Networking/VimeoClient/VIMSessionManager.h
+++ b/VIMNetworking/Networking/VimeoClient/VIMSessionManager.h
@@ -31,7 +31,4 @@
 - (nullable instancetype)initWithDefaultSession;
 - (nullable instancetype)initWithBackgroundSessionID:(nonnull NSString *)sessionID;
 
-- (nullable NSProgress *)downloadProgressForTaskIdentifier:(NSInteger)identifier;
-- (nullable NSURLSessionDownloadTask *)downloadTaskForIdentifier:(NSInteger)identifier;
-
 @end

--- a/VIMNetworking/Networking/VimeoClient/VIMSessionManager.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSessionManager.m
@@ -51,32 +51,6 @@
     return [self initWithBackgroundSessionID:sessionID sharedContainerID:nil];
 }
 
-- (NSProgress *)downloadProgressForTaskIdentifier:(NSInteger)identifier
-{
-    NSURLSessionDownloadTask *task = [self downloadTaskForIdentifier:identifier];
-    if (task)
-    {
-        return [self downloadProgressForTask:task];
-    }
-    
-    return nil;
-}
-
-- (NSURLSessionDownloadTask *)downloadTaskForIdentifier:(NSInteger)identifier
-{
-    NSArray *downloadTasks = self.downloadTasks;
-    
-    for (NSURLSessionDownloadTask *task in downloadTasks)
-    {
-        if (task.taskIdentifier == identifier)
-        {
-            return task;
-        }
-    }
-    
-    return nil;
-}
-
 #pragma mark - Private API
 
 - (instancetype)initWithBackgroundSessionID:(NSString *)sessionID sharedContainerID:(NSString *)sharedContainerID


### PR DESCRIPTION
#### Ticket
[VIM-3308](https://vimean.atlassian.net/browse/VIM-3308)

#### Ticket Summary
This ticket is part of building the new download system. This PR is a side effect of that work.

#### Implementation Summary
We're deprecating the old download system that relied on a few download-specific methods here. Removed those methods. Don't need 'em anymore.

#### How to Test
Aint no test.