### PR TITLE
VIM-3591: Added support for the new transcode_starting state

### DIFF
--- a/VIMNetworking/Model/VIMVideo.h
+++ b/VIMNetworking/Model/VIMVideo.h
@@ -45,6 +45,7 @@ extern NSString * __nonnull VIMContentRating_Safe;
 typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
     VIMVideoProcessingStatusAvailable,
     VIMVideoProcessingStatusUploading,
+    VIMVideoProcessingStatusTranscodeStarting, // New state added to API 11/18/2015 with in-app support added 2/11/2016 [AH]
     VIMVideoProcessingStatusTranscoding,
     VIMVideoProcessingStatusUploadingError,
     VIMVideoProcessingStatusTranscodingError,

--- a/VIMNetworking/Model/VIMVideo.m
+++ b/VIMNetworking/Model/VIMVideo.m
@@ -251,6 +251,7 @@ NSString *VIMContentRating_Safe = @"safe";
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusAvailable], @"available",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusUploading], @"uploading",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusTranscoding], @"transcoding",
+                                      [NSNumber numberWithInt:VIMVideoProcessingStatusTranscodeStarting], @"transcode_starting",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusUploadingError], @"uploading_error",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusTranscodingError], @"transcoding_error",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusQuotaExceeded], @"quota_exceeded",
@@ -315,7 +316,7 @@ NSString *VIMContentRating_Safe = @"safe";
 
 - (BOOL)isTranscoding
 {
-    return self.videoStatus == VIMVideoProcessingStatusTranscoding;
+    return self.videoStatus == VIMVideoProcessingStatusTranscoding || self.videoStatus == VIMVideoProcessingStatusTranscodeStarting;
 }
 
 - (BOOL)isUploading


### PR DESCRIPTION
#### Ticket
[VIM-3591](https://vimean.atlassian.net/browse/VIM-3591)

#### Ticket Summary
Add support for the new "transcode_starting" state for clip object "status".

#### Implementation Summary
Added this to VIMNetworking and the app.

#### How to Test
You'd have to refresh a just uploaded video object to see this. Might be difficult.