### PR TITLE
Removing Extension Logic

### DIFF
--- a/VIMNetworking/Keychain/VIMKeychain.m
+++ b/VIMNetworking/Keychain/VIMKeychain.m
@@ -85,6 +85,9 @@
 
     OSStatus status = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
     
+    // Not sure why, but SecItemAdd sometimes returns -34018. This looks like an Apple issue. [ghking] 2/19/2016
+    // See this SO post: http://stackoverflow.com/questions/20344255/secitemadd-and-secitemcopymatching-returns-error-code-34018-errsecmissingentit/22305193#22305193
+    
     return (status == errSecSuccess);
 }
 

--- a/VIMNetworking/Networking/VimeoClient/VIMSession.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSession.m
@@ -103,18 +103,6 @@ static VIMSession *_sharedSession;
 
 - (void)applicationDidEnterForeground:(NSNotification *)notification
 {
-    VIMAccountNew *originalAccount = self.account;
-    
-    self.account = [self loadAccountIfPossible]; // Reload account in the event that an auth event occurred in the an app extension
-    self.client.cache = [self buildCache];
-
-    if (![originalAccount.accessToken isEqualToString:self.account.accessToken])
-    {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[NSNotificationCenter defaultCenter] postNotificationName:VIMSession_AuthenticatedAccountDidChangeNotification object:nil];
-        });
-    }
-    
     if (self.currentUserRefreshRequest)
     {
         return;


### PR DESCRIPTION
#### Summary

Removing old extension auth logic. The app was sending out unnecessary VIMSession_AuthenticatedAccountDidChangeNotification notifications when the user was logged out after foregrounding.

Also adding a comment to weird keychain behavior that has been triggering some asserts. The problem looks like an Apple issue, but it has only been seen so far in dev. 