### PR TITLE
VIM-3712: update model for unlisted privacy

### DIFF
--- a/VIMNetworking/Model/VIMPrivacy.h
+++ b/VIMNetworking/Model/VIMPrivacy.h
@@ -32,6 +32,7 @@ extern NSString * __nonnull VIMPrivacy_Public;
 extern NSString * __nonnull VIMPrivacy_VOD;
 extern NSString * __nonnull VIMPrivacy_Following;
 extern NSString * __nonnull VIMPrivacy_Password;
+extern NSString * __nonnull VIMPrivacy_Unlisted;
 extern NSString * __nonnull VIMPrivacy_Disabled;
 
 @interface VIMPrivacy : VIMModelObject

--- a/VIMNetworking/Model/VIMPrivacy.m
+++ b/VIMNetworking/Model/VIMPrivacy.m
@@ -32,6 +32,7 @@ NSString *VIMPrivacy_Public = @"anybody";
 NSString *VIMPrivacy_VOD = @"ptv";
 NSString *VIMPrivacy_Following = @"contacts";
 NSString *VIMPrivacy_Password = @"password";
+NSString *VIMPrivacy_Unlisted = @"unlisted";
 NSString *VIMPrivacy_Disabled = @"disable";
 
 @implementation VIMPrivacy

--- a/VIMNetworking/Model/VIMVideo.h
+++ b/VIMNetworking/Model/VIMVideo.h
@@ -69,6 +69,7 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 @property (nonatomic, strong, nullable) NSDictionary *stats;
 @property (nonatomic, strong, nullable) NSArray *tags;
 @property (nonatomic, copy, nullable) NSString *uri;
+@property (nonatomic, copy, nullable) NSString *resourceKey;
 @property (nonatomic, strong, nullable) VIMUser *user;
 @property (nonatomic, copy, nullable) NSString *status;
 @property (nonatomic, copy, nullable) NSString *type;


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-3712](https://vimean.atlassian.net/browse/VIM-3712)
[Companion PR](https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/775) for context

#### Ticket Summary
Updated model for unlisted privacy

#### Implementation Summary
Updated `VIMPrivacy` for unlisted privacy setting. 
Updated `VIMVideo` to receive `resourceKey` from API, useful to identify videos given uri is mutable based on privacy setting. 

#### How to Test
Ensure params conform to correct naming convention 
Ensure `resourceKey` is accessible on a `VIMVideo` object

@huebnerob could you review and proceed with [VIM-3978](https://vimean.atlassian.net/browse/VIM-3978)? Thank you!
