### PR TITLE
VIM-3829: Adds delay to error call in VIMRequestOperationManager

### DIFF
--- a/VIMNetworking/Networking/VimeoClient/VIMRequestOperationManager.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMRequestOperationManager.m
@@ -346,7 +346,6 @@ NSString *const kVimeoClient_InvalidTokenNotification = @"kVimeoClient_InvalidTo
                 {
                     // Delay by a couple of seconds in case we're currently connecting [CL]
                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                        NSLog(@"Running this delayed stuff");
                         if (![VIMReachability sharedInstance].isNetworkReachable)
                         {
                             completionBlock(response, error);

--- a/VIMNetworking/Networking/VimeoClient/VIMRequestOperationManager.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMRequestOperationManager.m
@@ -24,6 +24,7 @@
 //  THE SOFTWARE.
 //
 
+#import "VIMReachability.h"
 #import "VIMRequestOperationManager.h"
 #import "AFHTTPRequestOperation.h"
 #import "VIMMappable.h"
@@ -343,7 +344,15 @@ NSString *const kVimeoClient_InvalidTokenNotification = @"kVimeoClient_InvalidTo
             {
                 if (completionBlock)
                 {
-                    completionBlock(response, error);
+                    // Delay by a couple of seconds in case we're currently connecting [CL]
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                        NSLog(@"Running this delayed stuff");
+                        if (![VIMReachability sharedInstance].isNetworkReachable)
+                        {
+                            completionBlock(response, error);
+                        }
+                    });
+                    
                 }
             }
             


### PR DESCRIPTION
#### Ticket
https://vimean.atlassian.net/browse/VIM-3829

#### Ticket Summary
Alert for No Internet Connection appears while still connecting.  First detected while uploading, but reproducible without uploading a video.

#### Implementation Summary
Adds a delay to the error display and checks reachability again before dispatching it.

#### How to Test
1. Go to 'Me' tab
2. Turn off network (turn on airplane mode)
3. Turn on network (turn off airplane mode)

previously an alert appeared, it no longer does.

