### PR TITLE
VIM-3675: Adds password to VIM Preferences

### DIFF
--- a/VIMNetworking/Model/VIMVideoPreference.h
+++ b/VIMNetworking/Model/VIMVideoPreference.h
@@ -29,5 +29,6 @@
 @interface VIMVideoPreference : VIMModelObject
 
 @property (nonatomic, copy, nullable) NSString *privacy;
+@property (nonatomic, copy, nullable) NSString *password;
 
 @end


### PR DESCRIPTION
#### Ticket
https://vimean.atlassian.net/browse/VIM-3675

#### Ticket Summary
1. On desktop, set your global upload privacy setting to 'password' and save a default password 
2. Open the app and upload a video 
3. Under password, tap 'set password'
User should see their default password. They should be able to proceed to Upload without checking it.

#### Implementation Summary
This works with another PR, adds video password to Preferences


