### PR TITLE
VIM-4042: Added Release Time to Video Object

### DIFF
--- a/VIMNetworking/Model/VIMVideo.h
+++ b/VIMNetworking/Model/VIMVideo.h
@@ -57,6 +57,7 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 
 @property (nonatomic, copy, nullable) NSArray *contentRating;
 @property (nonatomic, strong, nullable) NSDate *createdTime;
+@property (nonatomic, strong, nullable) NSDate *releaseTime;
 @property (nonatomic, strong, nullable) NSDate *modifiedTime;
 @property (nonatomic, copy, nullable) NSString *videoDescription;
 @property (nonatomic, strong, nullable) NSNumber *duration;

--- a/VIMNetworking/Model/VIMVideo.m
+++ b/VIMNetworking/Model/VIMVideo.m
@@ -147,6 +147,7 @@ NSString *VIMContentRating_Safe = @"safe";
     [self parseConnections];
     [self parseInteractions];
     [self formatCreatedTime];
+    [self formatReleaseTime];
     [self formatModifiedTime];
     
     id ob = [self.stats valueForKey:@"plays"];
@@ -246,6 +247,14 @@ NSString *VIMContentRating_Safe = @"safe";
     }
     
     self.interactions = interactions;
+}
+
+- (void)formatReleaseTime
+{
+    if ([self.releaseTime isKindOfClass:[NSString class]])
+    {
+        self.releaseTime = [[VIMModelObject dateFormatter] dateFromString:(NSString *)self.releaseTime];
+    }
 }
 
 - (void)formatCreatedTime


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-4042](https://vimean.atlassian.net/browse/VIM-4042)

parent PR: https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/860

#### Ticket Summary
Android is using release_time, if available, to display dates on videos and falling back on created_time

#### Implementation Summary
Added support to receive release_time on a video object 

#### How to Test
NA
