### PR TITLE
VIM-4087: Load Trailers for VOD items

### DIFF
--- a/VIMNetworking/Model/VIMVideo+VOD.h
+++ b/VIMNetworking/Model/VIMVideo+VOD.h
@@ -21,5 +21,6 @@ typedef NS_ENUM(NSUInteger, VIMVideoVODAccess) {
 - (BOOL)isVODTrailer;
 - (VIMVideoVODAccess)vodAccess;
 - (NSDate * _Nullable)expirationDateForAccess:(VIMVideoVODAccess)access;
+- (NSString * _Nullable)vodTrailerURI;
 
 @end

--- a/VIMNetworking/Networking/VimeoClient/VIMClient.h
+++ b/VIMNetworking/Networking/VimeoClient/VIMClient.h
@@ -81,6 +81,8 @@
 
 - (nullable id<VIMRequestToken>)videoWithURI:(nonnull NSString *)URI completionBlock:(nonnull VIMRequestCompletionBlock)completionBlock;
 
+- (nullable id<VIMRequestToken>)vodVideoWithURI:(nonnull NSString *)URI completionBlock:(nonnull VIMRequestCompletionBlock)completionBlock;
+
 - (nullable id<VIMRequestToken>)videosWithURI:(nonnull NSString *)URI completionBlock:(nonnull VIMRequestCompletionBlock)completionBlock;
 
 - (nullable id<VIMRequestToken>)updateVideoWithURI:(nonnull NSString *)URI title:(nullable NSString *)title description:(nullable NSString *)description privacy:(nullable NSString *)privacy completionHandler:(nonnull VIMRequestCompletionBlock)completionBlock;

--- a/VIMNetworking/Networking/VimeoClient/VIMClient.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMClient.m
@@ -269,7 +269,6 @@ static NSString *const ModelKeyPathData = @"data";
     VIMRequestDescriptor *descriptor = [[VIMRequestDescriptor alloc] init];
     descriptor.urlPath = URI;
     descriptor.modelClass = [VIMVideo class];
-    descriptor.modelKeyPath = @"";
     descriptor.parameters = @{@"_video_override" : @"true"};
     
     return [self requestDescriptor:descriptor completionBlock:completionBlock];

--- a/VIMNetworking/Networking/VimeoClient/VIMClient.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMClient.m
@@ -254,12 +254,23 @@ static NSString *const ModelKeyPathData = @"data";
 
 #pragma mark - Videos
 
-- (id<VIMRequestToken>)videoWithURI:(NSString *)URI completionBlock:(VIMRequestCompletionBlock)completionBlock;
+- (id<VIMRequestToken>)videoWithURI:(NSString *)URI completionBlock:(VIMRequestCompletionBlock)completionBlock
 {
     VIMRequestDescriptor *descriptor = [[VIMRequestDescriptor alloc] init];
     descriptor.urlPath = URI;
     descriptor.modelClass = [VIMVideo class];
     descriptor.modelKeyPath = @"";
+    
+    return [self requestDescriptor:descriptor completionBlock:completionBlock];
+}
+
+- (id<VIMRequestToken>)vodVideoWithURI:(NSString *)URI completionBlock:(VIMRequestCompletionBlock)completionBlock
+{
+    VIMRequestDescriptor *descriptor = [[VIMRequestDescriptor alloc] init];
+    descriptor.urlPath = URI;
+    descriptor.modelClass = [VIMVideo class];
+    descriptor.modelKeyPath = @"";
+    descriptor.parameters = @{@"_video_override" : @"true"};
     
     return [self requestDescriptor:descriptor completionBlock:completionBlock];
 }

--- a/VIMNetworking/Networking/VimeoClient/VIMJSONResponseSerializer.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMJSONResponseSerializer.m
@@ -56,6 +56,7 @@
                                  @"application/vnd.vimeo.category+json",
                                  @"application/vnd.vimeo.channel+json",
                                  @"application/vnd.vimeo.ondemand.page+json",
+                                 @"application/vnd.vimeo.ondemand.video+json",
                                  nil];
 }
 


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-4087](https://vimean.atlassian.net/browse/VIM-4087)

#### Ticket Summary
We need to access the VOD trailer URI from a VIMVideo.

#### Implementation Summary
Function prototype was added to `VIMVideo+VOD` header for method `vodTrailerURI` so it would be publicly accessible.

#### How to Test
NA
