### PR TITLE
VIM-4264: Add emails to user model

### DIFF
--- a/VIMNetworking/Model/VIMUser.h
+++ b/VIMNetworking/Model/VIMUser.h
@@ -54,6 +54,7 @@ typedef NS_ENUM(NSInteger, VIMUserAccountType)
 @property (nonatomic, strong, nullable) id stats;
 @property (nonatomic, copy, nullable) NSString *uri;
 @property (nonatomic, strong, nullable) NSArray *websites;
+@property (nonatomic, strong, nullable) NSArray *userEmails;
 @property (nonatomic, strong, nullable) VIMPreference *preferences;
 @property (nonatomic, strong, nullable) VIMUploadQuota *uploadQuota;
 @property (nonatomic, copy, nullable) NSString *account;

--- a/VIMNetworking/Model/VIMUser.m
+++ b/VIMNetworking/Model/VIMUser.m
@@ -38,6 +38,7 @@
 @property (nonatomic, strong) NSDictionary *metadata;
 @property (nonatomic, strong) NSDictionary *connections;
 @property (nonatomic, strong) NSDictionary *interactions;
+@property (nonatomic, strong, nullable) NSArray *emails;
 
 @property (nonatomic, assign, readwrite) VIMUserAccountType accountType;
 
@@ -97,6 +98,7 @@
     [self parseConnections];
     [self parseInteractions];
     [self parseAccountType];
+    [self parseEmails];
     [self formatCreatedTime];
     [self formatModifiedTime];
 }
@@ -162,6 +164,23 @@
     {
         self.accountType = VIMUserAccountTypeBasic;
     }
+}
+
+- (void)parseEmails
+{
+    NSMutableArray *parsedEmails = [[NSMutableArray alloc] init];
+    
+    for (NSDictionary *email in self.emails)
+    {
+        NSString *emailString = email[@"email"];
+        
+        if (emailString)
+        {
+            [parsedEmails addObject:emailString];
+        }
+    }
+    
+    self.userEmails = [NSArray arrayWithArray:parsedEmails];
 }
 
 - (void)formatCreatedTime

--- a/VIMNetworking/Model/VIMUser.m
+++ b/VIMNetworking/Model/VIMUser.m
@@ -180,7 +180,7 @@
         }
     }
     
-    self.userEmails = [NSArray arrayWithArray:parsedEmails];
+    self.userEmails = parsedEmails; 
 }
 
 - (void)formatCreatedTime


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-4264](https://vimean.atlassian.net/browse/VIM-4264)

#### Ticket Summary
Make emails accessible on user object.

#### Implementation Summary
The emails object is received as an array of dictionaries holding "email":"emailString" key value pairs.  To make them more accessible, the email string values are grabbed and stored in the  `userEmails` array property on user object. 

#### How to Test
See parent ticket referencing this.
