### PR TITLE
VIM-4411: FairPlay DRM Models

### DIFF
--- a/VIMNetworking/Model/VIMVideo.h
+++ b/VIMNetworking/Model/VIMVideo.h
@@ -103,6 +103,7 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (BOOL)isRatedAllAudiences;
 - (BOOL)isNotYetRated;
 - (BOOL)isRatedMature;
+- (BOOL)isDRMProtected;
 - (NSInteger)likesCount;
 - (NSInteger)commentsCount;
 

--- a/VIMNetworking/Model/VIMVideo.m
+++ b/VIMNetworking/Model/VIMVideo.m
@@ -39,6 +39,7 @@
 #import "VIMVideoLog.h"
 #import "VIMCategory.h"
 #import "VIMVideoPlayRepresentation.h"
+#import "VIMVideoDRMFiles.h"
 
 NSString *VIMContentRating_Language = @"language";
 NSString *VIMContentRating_Drugs = @"drugs";
@@ -399,6 +400,10 @@ NSString *VIMContentRating_Safe = @"safe";
     return ![contentRating isEqualToString:VIMContentRating_Unrated] && ![contentRating isEqualToString:VIMContentRating_Safe];
 }
 
+- (BOOL)isDRMProtected
+{
+    return self.playRepresentation.drmFiles.fairPlayFile != nil;
+}
 
 - (NSString *)singleContentRatingIfAvailable
 {

--- a/VIMNetworking/Model/VIMVideoDRMFiles.h
+++ b/VIMNetworking/Model/VIMVideoDRMFiles.h
@@ -1,0 +1,15 @@
+//
+//  VIMVideoDRMFiles.h
+//  Vimeo
+//
+//  Created by King, Gavin on 7/13/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+@class VIMVideoFairPlayFile;
+
+@interface VIMVideoDRMFiles : VIMModelObject
+
+@property (nonatomic, strong, nullable) VIMVideoFairPlayFile *fairPlayFile;
+
+@end

--- a/VIMNetworking/Model/VIMVideoDRMFiles.h
+++ b/VIMNetworking/Model/VIMVideoDRMFiles.h
@@ -5,6 +5,24 @@
 //  Created by King, Gavin on 7/13/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 @class VIMVideoFairPlayFile;
 

--- a/VIMNetworking/Model/VIMVideoDRMFiles.m
+++ b/VIMNetworking/Model/VIMVideoDRMFiles.m
@@ -20,7 +20,7 @@
 
 - (Class)getClassForObjectKey:(NSString *)key
 {
-    if( [key isEqualToString:@"fairplay"] )
+    if ([key isEqualToString:@"fairplay"])
     {
         return [VIMVideoFairPlayFile class];
     }

--- a/VIMNetworking/Model/VIMVideoDRMFiles.m
+++ b/VIMNetworking/Model/VIMVideoDRMFiles.m
@@ -5,6 +5,24 @@
 //  Created by King, Gavin on 7/13/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #import "VIMVideoDRMFiles.h"
 #import "VIMVideoFairPlayFile.h"

--- a/VIMNetworking/Model/VIMVideoDRMFiles.m
+++ b/VIMNetworking/Model/VIMVideoDRMFiles.m
@@ -1,0 +1,31 @@
+//
+//  VIMVideoDRMFiles.m
+//  Vimeo
+//
+//  Created by King, Gavin on 7/13/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+#import "VIMVideoDRMFiles.h"
+#import "VIMVideoFairPlayFile.h"
+
+@implementation VIMVideoDRMFiles
+
+#pragma mark - VIMMappable
+
+- (NSDictionary *)getObjectMapping
+{
+    return @{@"fairplay": @"fairPlayFile"};
+}
+
+- (Class)getClassForObjectKey:(NSString *)key
+{
+    if( [key isEqualToString:@"fairplay"] )
+    {
+        return [VIMVideoFairPlayFile class];
+    }
+    
+    return nil;
+}
+
+@end

--- a/VIMNetworking/Model/VIMVideoFairPlayFile.h
+++ b/VIMNetworking/Model/VIMVideoFairPlayFile.h
@@ -5,8 +5,24 @@
 //  Created by King, Gavin on 7/13/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
-
-#import <Foundation/Foundation.h>
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #import "VIMVideoPlayFile.h"
 

--- a/VIMNetworking/Model/VIMVideoFairPlayFile.h
+++ b/VIMNetworking/Model/VIMVideoFairPlayFile.h
@@ -1,0 +1,19 @@
+//
+//  VIMVideoFairPlayFile.h
+//  Vimeo
+//
+//  Created by King, Gavin on 7/13/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "VIMVideoPlayFile.h"
+
+@interface VIMVideoFairPlayFile : VIMVideoHLSFile
+
+@property (nonatomic, copy, nullable) NSString *token;
+@property (nonatomic, copy, nullable) NSString *certificateLink;
+@property (nonatomic, copy, nullable) NSString *licenseLink;
+
+@end

--- a/VIMNetworking/Model/VIMVideoFairPlayFile.m
+++ b/VIMNetworking/Model/VIMVideoFairPlayFile.m
@@ -1,0 +1,24 @@
+//
+//  VIMVideoFairPlayFile.m
+//  Vimeo
+//
+//  Created by King, Gavin on 7/13/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+#import "VIMVideoFairPlayFile.h"
+
+@implementation VIMVideoFairPlayFile
+
+#pragma mark - VIMMappable
+
+- (NSDictionary *)getObjectMapping
+{
+    NSMutableDictionary *mapping = [[super getObjectMapping] mutableCopy];
+    
+    [mapping addEntriesFromDictionary:@{@"certificate_link": @"certificateLink", @"license_link": @"licenseLink"}];
+    
+    return mapping;
+}
+
+@end

--- a/VIMNetworking/Model/VIMVideoFairPlayFile.m
+++ b/VIMNetworking/Model/VIMVideoFairPlayFile.m
@@ -5,6 +5,24 @@
 //  Created by King, Gavin on 7/13/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #import "VIMVideoFairPlayFile.h"
 

--- a/VIMNetworking/Model/VIMVideoFairPlayFile.m
+++ b/VIMNetworking/Model/VIMVideoFairPlayFile.m
@@ -28,15 +28,4 @@
 
 @implementation VIMVideoFairPlayFile
 
-#pragma mark - VIMMappable
-
-- (NSDictionary *)getObjectMapping
-{
-    NSMutableDictionary *mapping = [[super getObjectMapping] mutableCopy];
-    
-    [mapping addEntriesFromDictionary:@{@"certificate_link": @"certificateLink", @"license_link": @"licenseLink"}];
-    
-    return mapping;
-}
-
 @end

--- a/VIMNetworking/Model/VIMVideoLog.h
+++ b/VIMNetworking/Model/VIMVideoLog.h
@@ -30,6 +30,7 @@
 
 @property (nonatomic, copy, readonly, nullable) NSString *playURLString;
 @property (nonatomic, copy, readonly, nullable) NSString *loadURLString;
+@property (nonatomic, copy, readonly, nullable) NSString *exitURLString;
 @property (nonatomic, copy, readonly, nullable) NSString *likeURLString;
 @property (nonatomic, copy, readonly, nullable) NSString *watchLaterURLString;
 

--- a/VIMNetworking/Model/VIMVideoLog.m
+++ b/VIMNetworking/Model/VIMVideoLog.m
@@ -30,6 +30,7 @@
 
 @property (nonatomic, copy, readwrite) NSString *playURLString;
 @property (nonatomic, copy, readwrite) NSString *loadURLString;
+@property (nonatomic, copy, readwrite) NSString *exitURLString;
 @property (nonatomic, copy, readwrite) NSString *likeURLString;
 @property (nonatomic, copy, readwrite) NSString *watchLaterURLString;
 
@@ -43,6 +44,7 @@
 {
     return @{@"play_link": @"playURLString",
              @"load_link": @"loadURLString",
+             @"exit_link": @"exitURLString",
              @"like_press_link" : @"likeURLString",
              @"watchlater_press_link" : @"watchLaterURLString"};
 }

--- a/VIMNetworking/Model/VIMVideoPlayRepresentation.h
+++ b/VIMNetworking/Model/VIMVideoPlayRepresentation.h
@@ -28,6 +28,7 @@
 
 @class VIMVideoHLSFile;
 @class VIMVideoDASHFile;
+@class VIMVideoDRMFiles;
 @class VIMVideoProgressiveFile;
 
 typedef NS_ENUM(NSUInteger, VIMVideoPlayabilityStatus) {
@@ -41,6 +42,7 @@ typedef NS_ENUM(NSUInteger, VIMVideoPlayabilityStatus) {
 
 @property (nonatomic, strong, nullable) VIMVideoHLSFile *hlsFile;
 @property (nonatomic, strong, nullable) VIMVideoDASHFile *dashFile;
+@property (nonatomic, strong, nullable) VIMVideoDRMFiles *drmFiles;
 @property (nonatomic, strong, nullable) NSArray<VIMVideoProgressiveFile *> *progressiveFiles;
 @property (nonatomic, assign) VIMVideoPlayabilityStatus playabilityStatus;
 

--- a/VIMNetworking/Model/VIMVideoPlayRepresentation.m
+++ b/VIMNetworking/Model/VIMVideoPlayRepresentation.m
@@ -28,6 +28,7 @@
 #import "VIMVideoPlayRepresentation.h"
 #import "VIMVideoHLSFile.h"
 #import "VIMVideoDASHFile.h"
+#import "VIMVideoDRMFiles.h"
 #import "VIMVideoProgressiveFile.h"
 #import "VIMVideoLog.h"
 
@@ -48,9 +49,10 @@
 
 - (NSDictionary *)getObjectMapping
 {
-    return @{@"progressive": @"progressiveFiles",
-             @"hls": @"hlsFile",
-             @"dash": @"dashFile"};
+    return @{@"hls": @"hlsFile",
+             @"dash": @"dashFile",
+             @"drm": @"drmFiles",
+             @"progressive": @"progressiveFiles"};
 }
 
 - (Class)getClassForObjectKey:(NSString *)key
@@ -63,6 +65,11 @@
     if( [key isEqualToString:@"dash"] )
     {
         return [VIMVideoDASHFile class];
+    }
+    
+    if( [key isEqualToString:@"drm"] )
+    {
+        return [VIMVideoDRMFiles class];
     }
     
     return nil;

--- a/VIMNetworking/Model/VIMVideoPlayRepresentation.m
+++ b/VIMNetworking/Model/VIMVideoPlayRepresentation.m
@@ -57,17 +57,17 @@
 
 - (Class)getClassForObjectKey:(NSString *)key
 {
-    if( [key isEqualToString:@"hls"] )
+    if ([key isEqualToString:@"hls"])
     {
         return [VIMVideoHLSFile class];
     }
     
-    if( [key isEqualToString:@"dash"] )
+    if ([key isEqualToString:@"dash"])
     {
         return [VIMVideoDASHFile class];
     }
     
-    if( [key isEqualToString:@"drm"] )
+    if ([key isEqualToString:@"drm"])
     {
         return [VIMVideoDRMFiles class];
     }
@@ -77,7 +77,7 @@
 
 - (Class)getClassForCollectionKey:(NSString *)key
 {
-    if([key isEqualToString:@"progressive"])
+    if ([key isEqualToString:@"progressive"])
     {
         return [VIMVideoProgressiveFile class];
     }


### PR DESCRIPTION
#### Ticket

https://vimean.atlassian.net/browse/VIM-4411

#### Ticket Summary

This ticket adds the FairPlay DRM models to the video model.

#### Implementation Summary

Added the necessary models to the video model.

#### How to Test

Go to the the profile for "TC Test Account" and play the "Caminandes : Llama Drama" video. Ensure that the correct video>play>drm>fairplay fields are populated.