### PR TITLE
VIM-4306: Add badge to response filter

### DIFF
--- a/VIMNetworking/Model/VIMUser.h
+++ b/VIMNetworking/Model/VIMUser.h
@@ -37,12 +37,14 @@ typedef NS_ENUM(NSInteger, VIMUserAccountType)
     VIMUserAccountTypeBasic = 0,
     VIMUserAccountTypePro,
     VIMUserAccountTypePlus,
-    VIMUserAccountTypeStaff
+    VIMUserAccountTypeStaff,
+    VIMUserAccountTypeBusiness
 };
 
 @interface VIMUser : VIMModelObject
 
 @property (nonatomic, assign, readonly) VIMUserAccountType accountType;
+@property (nonatomic, copy, nullable) NSDictionary *badge;
 @property (nonatomic, copy, nullable) NSString *bio;
 @property (nonatomic, copy, nullable) NSArray *contentFilter;
 @property (nonatomic, strong, nullable) NSDate *createdTime;

--- a/VIMNetworking/Model/VIMUser.h
+++ b/VIMNetworking/Model/VIMUser.h
@@ -31,20 +31,20 @@
 @class VIMPictureCollection;
 @class VIMPreference;
 @class VIMUploadQuota;
+@class VIMUserBadge;
 
 typedef NS_ENUM(NSInteger, VIMUserAccountType)
 {
     VIMUserAccountTypeBasic = 0,
     VIMUserAccountTypePro,
     VIMUserAccountTypePlus,
-    VIMUserAccountTypeStaff,
     VIMUserAccountTypeBusiness
 };
 
 @interface VIMUser : VIMModelObject
 
 @property (nonatomic, assign, readonly) VIMUserAccountType accountType;
-@property (nonatomic, copy, nullable) NSDictionary *badge;
+@property (nonatomic, copy, nullable) VIMUserBadge *badge;
 @property (nonatomic, copy, nullable) NSString *bio;
 @property (nonatomic, copy, nullable) NSArray *contentFilter;
 @property (nonatomic, strong, nullable) NSDate *createdTime;

--- a/VIMNetworking/Model/VIMUser.h
+++ b/VIMNetworking/Model/VIMUser.h
@@ -44,7 +44,7 @@ typedef NS_ENUM(NSInteger, VIMUserAccountType)
 @interface VIMUser : VIMModelObject
 
 @property (nonatomic, assign, readonly) VIMUserAccountType accountType;
-@property (nonatomic, copy, nullable) VIMUserBadge *badge;
+@property (nonatomic, strong, nullable) VIMUserBadge *badge;
 @property (nonatomic, copy, nullable) NSString *bio;
 @property (nonatomic, copy, nullable) NSArray *contentFilter;
 @property (nonatomic, strong, nullable) NSDate *createdTime;

--- a/VIMNetworking/Model/VIMUser.m
+++ b/VIMNetworking/Model/VIMUser.m
@@ -162,6 +162,10 @@
     {
         self.accountType = VIMUserAccountTypeBasic;
     }
+    else if ([self.account isEqualToString:@"business"])
+    {
+        self.accountType = VIMUserAccountTypeBusiness;
+    }
 }
 
 - (void)formatCreatedTime
@@ -210,6 +214,9 @@
             break;
         case VIMUserAccountTypeStaff:
             return @"staff";
+            break;
+        case VIMUserAccountTypeBusiness:
+            return @"business";
             break;
     }
 }

--- a/VIMNetworking/Model/VIMUser.m
+++ b/VIMNetworking/Model/VIMUser.m
@@ -32,6 +32,7 @@
 #import "VIMPicture.h"
 #import "VIMPreference.h"
 #import "VIMUploadQuota.h"
+#import "VIMUserBadge.h"
 
 @interface VIMUser ()
 
@@ -66,6 +67,11 @@
 
 - (Class)getClassForObjectKey:(NSString *)key
 {
+    if ([key isEqualToString:@"badge"])
+    {
+        return [VIMUserBadge class];
+    }
+    
     if ([key isEqualToString:@"pictures"])
     {
         return [VIMPictureCollection class];
@@ -205,19 +211,12 @@
         default:
         case VIMUserAccountTypeBasic:
             return @"basic";
-            break;
         case VIMUserAccountTypePlus:
             return @"plus";
-            break;
         case VIMUserAccountTypePro:
             return @"pro";
-            break;
-        case VIMUserAccountTypeStaff:
-            return @"staff";
-            break;
         case VIMUserAccountTypeBusiness:
             return @"business";
-            break;
     }
 }
 

--- a/VIMNetworking/Model/VIMUserBadge.h
+++ b/VIMNetworking/Model/VIMUserBadge.h
@@ -1,0 +1,49 @@
+//
+//  VIMUserBadge.h
+//  Vimeo
+//
+//  Created by Jake Oliver on 8/8/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "VIMModelObject.h"
+
+typedef NS_ENUM(NSInteger, VIMUserBadgeType)
+{
+    VIMUserBadgeTypeDefault = 0,
+    VIMUserBadgeTypePlus,
+    VIMUserBadgeTypePro,
+    VIMUserBadgeTypeBusiness,
+    VIMUserBadgeTypeAlum,
+    VIMUserBadgeTypeStaff,
+    VIMUserBadgeTypeSupport,
+    VIMUserBadgeTypeCuration
+};
+
+@interface VIMUserBadge : VIMModelObject
+
+@property (nonatomic, copy, nullable) NSString *alt_text;
+@property (nonatomic, copy, nullable) NSString *type;
+@property (nonatomic, assign) VIMUserBadgeType badgeType;
+@property (nonatomic, copy, nullable) NSString *text;
+@property (nonatomic, copy, nullable) NSString *url;
+
+@end

--- a/VIMNetworking/Model/VIMUserBadge.m
+++ b/VIMNetworking/Model/VIMUserBadge.m
@@ -28,6 +28,14 @@
 
 @implementation VIMUserBadge
 
+static const NSString *Plus = @"plus";
+static const NSString *Pro = @"pro";
+static const NSString *Business = @"business";
+static const NSString *Staff = @"staff";
+static const NSString *Curation = @"curation";
+static const NSString *Support = @"support";
+static const NSString *Alum = @"alum";
+
 - (void)didFinishMapping
 {
     [self parseBadge];
@@ -35,31 +43,31 @@
 
 - (void)parseBadge
 {
-    if ([self.type isEqualToString:@"plus"])
+    if ([self.type isEqualToString:Plus])
     {
         self.badgeType = VIMUserBadgeTypePlus;
     }
-    else if ([self.type isEqualToString:@"pro"])
+    else if ([self.type isEqualToString:Pro])
     {
         self.badgeType = VIMUserBadgeTypePro;
     }
-    else if ([self.type isEqualToString:@"business"])
+    else if ([self.type isEqualToString:Business])
     {
         self.badgeType = VIMUserBadgeTypeBusiness;
     }
-    else if ([self.type isEqualToString:@"staff"])
+    else if ([self.type isEqualToString:Staff])
     {
         self.badgeType = VIMUserBadgeTypeStaff;
     }
-    else if ([self.type isEqualToString:@"curation"])
+    else if ([self.type isEqualToString:Curation])
     {
         self.badgeType = VIMUserBadgeTypeCuration;
     }
-    else if ([self.type isEqualToString:@"support"])
+    else if ([self.type isEqualToString:Support])
     {
         self.badgeType = VIMUserBadgeTypeSupport;
     }
-    else if ([self.type isEqualToString:@"alum"])
+    else if ([self.type isEqualToString:Alum])
     {
         self.badgeType = VIMUserBadgeTypeAlum;
     }

--- a/VIMNetworking/Model/VIMUserBadge.m
+++ b/VIMNetworking/Model/VIMUserBadge.m
@@ -28,13 +28,13 @@
 
 @implementation VIMUserBadge
 
-static const NSString *Plus = @"plus";
-static const NSString *Pro = @"pro";
-static const NSString *Business = @"business";
-static const NSString *Staff = @"staff";
-static const NSString *Curation = @"curation";
-static const NSString *Support = @"support";
-static const NSString *Alum = @"alum";
+static NSString *const Plus = @"plus";
+static NSString *const Pro = @"pro";
+static NSString *const Business = @"business";
+static NSString *const Staff = @"staff";
+static NSString *const Curation = @"curation";
+static NSString *const Support = @"support";
+static NSString *const Alum = @"alum";
 
 - (void)didFinishMapping
 {

--- a/VIMNetworking/Model/VIMUserBadge.m
+++ b/VIMNetworking/Model/VIMUserBadge.m
@@ -1,0 +1,72 @@
+//
+//  VIMUserBadge.m
+//  Vimeo
+//
+//  Created by Jake Oliver on 8/8/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "VIMUserBadge.h"
+
+@implementation VIMUserBadge
+
+- (void)didFinishMapping
+{
+    [self parseBadge];
+}
+
+- (void)parseBadge
+{
+    if ([self.type isEqualToString:@"plus"])
+    {
+        self.badgeType = VIMUserBadgeTypePlus;
+    }
+    else if ([self.type isEqualToString:@"pro"])
+    {
+        self.badgeType = VIMUserBadgeTypePro;
+    }
+    else if ([self.type isEqualToString:@"business"])
+    {
+        self.badgeType = VIMUserBadgeTypeBusiness;
+    }
+    else if ([self.type isEqualToString:@"staff"])
+    {
+        self.badgeType = VIMUserBadgeTypeStaff;
+    }
+    else if ([self.type isEqualToString:@"curation"])
+    {
+        self.badgeType = VIMUserBadgeTypeCuration;
+    }
+    else if ([self.type isEqualToString:@"support"])
+    {
+        self.badgeType = VIMUserBadgeTypeSupport;
+    }
+    else if ([self.type isEqualToString:@"alum"])
+    {
+        self.badgeType = VIMUserBadgeTypeAlum;
+    }
+    else
+    {
+        self.badgeType = VIMUserBadgeTypeDefault;
+    }
+}
+
+@end

--- a/VIMNetworking/Networking/VimeoClient/VIMSession.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSession.m
@@ -236,7 +236,7 @@ static VIMSession *_sharedSession;
     
     BOOL success = [VIMAccountStore saveAccount:account forKey:key];
     
-    // NSAssert(success, @"Unable to save account for key: %@", key);
+    NSAssert(success, @"Unable to save account for key: %@", key);
     
     if (!success)
     {
@@ -502,7 +502,7 @@ static VIMSession *_sharedSession;
         strongSelf.account.userJSON = response.result;
         
         BOOL success = [VIMAccountStore saveAccount:strongSelf.account forKey:UserAccountKey];
-        // NSAssert(success, @"Unable to save account for key: %@", UserAccountKey);
+        NSAssert(success, @"Unable to save account for key: %@", UserAccountKey);
         
         if (!success)
         {

--- a/VIMNetworking/Networking/VimeoClient/VIMSession.m
+++ b/VIMNetworking/Networking/VimeoClient/VIMSession.m
@@ -236,7 +236,7 @@ static VIMSession *_sharedSession;
     
     BOOL success = [VIMAccountStore saveAccount:account forKey:key];
     
-    NSAssert(success, @"Unable to save account for key: %@", key);
+    // NSAssert(success, @"Unable to save account for key: %@", key);
     
     if (!success)
     {
@@ -502,7 +502,7 @@ static VIMSession *_sharedSession;
         strongSelf.account.userJSON = response.result;
         
         BOOL success = [VIMAccountStore saveAccount:strongSelf.account forKey:UserAccountKey];
-        NSAssert(success, @"Unable to save account for key: %@", UserAccountKey);
+        // NSAssert(success, @"Unable to save account for key: %@", UserAccountKey);
         
         if (!success)
         {


### PR DESCRIPTION
_original PR review comments can be found [here](https://github.com/vimeo/VIMNetworking/pull/204)_
#### Ticket
[4306](https://vimean.atlassian.net/browse/VIM-4306)

#### Ticket Summary
Implement badges from the user api response and adds new badges (staff, curation, alum, etc)

#### Implementation Summary
Adds the new business account type tier and the badge property to VIMUser

Associated PR: https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/931