### PR TITLE
VIM-4255: Serve helpful error when unverified user attempts to comment

### DIFF
--- a/VIMNetworking/Networking/ErrorReporting/NSError+VIMNetworking.h
+++ b/VIMNetworking/Networking/ErrorReporting/NSError+VIMNetworking.h
@@ -51,6 +51,7 @@ typedef NS_ENUM(NSInteger, VIMErrorCode)
     VIMErrorCodeEmailSpammer = 2402,
     VIMErrorCodeEmailPurgatory = 2403,
     VIMErrorCodeURLUnavailable = 2404,
+    VIMErrorCodeUnallowedToCommentEmailUnverified = 3411,
     VIMErrorCodeDRMStreamLimitHit = 3420,
     VIMErrorCodeDRMDeviceLimitHit = 3421,
     VIMErrorCodeTimeout = 5000,


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VIM-4255](https://vimean.atlassian.net/browse/VIM-4255)

#### Ticket Summary
Add case to support new api error 

#### Implementation Summary
Added case to support new api error 

#### How to Test
See associated parent PR
https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/994